### PR TITLE
Skip doctring length in FunctionTooLongRule

### DIFF
--- a/flake8_jungle/rules/jg06_function_too_long.py
+++ b/flake8_jungle/rules/jg06_function_too_long.py
@@ -27,6 +27,10 @@ class FunctionTooLongRule(Rule[FunctionType]):
             return issues
         length = node.end_lineno - node.lineno
 
+        docstring: str = ast.get_docstring(node, clean=False)
+        if docstring:
+            length -= len(docstring.splitlines())
+
         if length > self.options.max_function_length:
             issues.append(
                 JG06(

--- a/flake8_jungle/rules/jg06_function_too_long.py
+++ b/flake8_jungle/rules/jg06_function_too_long.py
@@ -27,7 +27,7 @@ class FunctionTooLongRule(Rule[FunctionType]):
             return issues
         length = node.end_lineno - node.lineno
 
-        docstring: str = ast.get_docstring(node, clean=False)
+        docstring: str | None = ast.get_docstring(node, clean=False)
         if docstring:
             length -= len(docstring.splitlines())
 

--- a/tests/fixtures/function_too_long.py
+++ b/tests/fixtures/function_too_long.py
@@ -1,4 +1,14 @@
 def foo(a=5):
+    """Function for testing purpose
+
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin dignissim egestas ligula in porta.
+    Nulla molestie neque vel tortor pellentesque lacinia. Phasellus eget malesuada lorem. Aliquam sollicitudin nisl
+    urna, sit amet ullamcorper ex tincidunt at. Donec pretium arcu sed turpis gravida pellentesque. Aenean fringilla
+    nisl et tempus imperdiet. Curabitur ut velit eu arcu gravida ultricies. Maecenas eget consequat quam.
+
+    :param a: random int input
+    :return: random useful string
+    """
     for _ in range(10):
         a += 1
     print("bar")

--- a/tests/test_function_too_long.py
+++ b/tests/test_function_too_long.py
@@ -11,7 +11,9 @@ from .utils import error_code_in_result, load_fixture_file, run_check
 )
 def test_is_function_too_long(function_max_length: int, function_result: int):
     code = load_fixture_file("function_too_long.py")
-    result = run_check(code, options=RuleOptions(max_function_length=function_max_length))
+    result = run_check(
+        code, options=RuleOptions(max_function_length=function_max_length)
+    )
     assert len(result) == function_result
     if function_result == 1:
         assert error_code_in_result("JG06", result)

--- a/tests/test_function_too_long.py
+++ b/tests/test_function_too_long.py
@@ -1,13 +1,20 @@
+import pytest as pytest
+
 from flake8_jungle.rules import RuleOptions
 
 from .utils import error_code_in_result, load_fixture_file, run_check
 
 
-def test_is_function_too_long():
+@pytest.mark.parametrize(
+    "function_max_length, function_result",
+    [(10, 1), (30, 1), (31, 0), (500, 0)],
+)
+def test_is_function_too_long(function_max_length: int, function_result: int):
     code = load_fixture_file("function_too_long.py")
-    result = run_check(code, options=RuleOptions(max_function_length=10))
-    assert len(result) == 1
-    assert error_code_in_result("JG06", result)
+    result = run_check(code, options=RuleOptions(max_function_length=function_max_length))
+    assert len(result) == function_result
+    if function_result == 1:
+        assert error_code_in_result("JG06", result)
 
 
 def test_is_not_function_too_long():


### PR DESCRIPTION
The docstring length should be skipped in FunctionTooLongRule because docstring is not a function implementation. The developer should not be discouraged from writing a docstring to optimize the length of the method.

https://twisto.slack.com/archives/C019SAB9VT7/p1665133266026339